### PR TITLE
mlog: create func GetOutput that allows to reuse the same output

### DIFF
--- a/mlog/minilog.go
+++ b/mlog/minilog.go
@@ -11,11 +11,22 @@ import (
 
 type Level int
 
+var output io.Writer
+
 const (
 	Normal Level = iota
 	Debug
 	Trace
 )
+
+func setOutputWriter(writer io.Writer) {
+	output = writer
+	log.SetOutput(writer)
+}
+
+func GetOutput() io.Writer {
+	return output
+}
 
 func SetOutput(logdir, service string, stdout bool) {
 	rl := rotatelogs.NewRotateLogs(
@@ -26,15 +37,15 @@ func SetOutput(logdir, service string, stdout bool) {
 	rl.LinkName = logdir + "/" + service + ".log"
 
 	if stdout {
-		log.SetOutput(io.MultiWriter(os.Stdout, rl))
+		setOutputWriter(io.MultiWriter(os.Stdout, rl))
 	} else {
-		log.SetOutput(rl)
+		setOutputWriter(rl)
 	}
 }
 
 func SetRawStream(w io.Writer) {
 	log.SetFlags(0)
-	log.SetOutput(w)
+	setOutputWriter(w)
 }
 
 func (ll Level) Debugf(format string, a ...interface{}) {

--- a/mlog/minilog_test.go
+++ b/mlog/minilog_test.go
@@ -1,0 +1,32 @@
+package mlog
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+func TestGetOutput(t *testing.T) {
+	actual := GetOutput()
+	if actual != nil {
+		t.Errorf("actual output %v is different from the expected (nil)", actual)
+	}
+}
+
+func TestSetRawStream(t *testing.T) {
+	log.SetFlags(0)
+	expectedOutput := &bytes.Buffer{}
+	SetRawStream(expectedOutput)
+	actualOutput := GetOutput()
+	if actualOutput == nil {
+		t.Errorf("actual output %v is different from the expected (not nil)", actualOutput)
+	}
+
+	logMessage := "sample message"
+	expectedLog := logMessage + "\n"
+	log.Print(logMessage)
+	actualLog := expectedOutput.String()
+	if actualLog != expectedLog {
+		t.Errorf("actual log '%s' is different from the expected '%s'", actualLog, expectedLog)
+	}
+}


### PR DESCRIPTION
This change is required so access logs in carbonapi can be written to the same file as the rest of the logs, but without the timestamp log.SetFlags(0).

Access logs have their own timestamp format.