### PR TITLE
Add 'InternalMetricPrefix' for internal metric name prefix

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -20,6 +20,10 @@
     // Interval seconds to send zipper's own metrics.
     "IntervalSec": 60,
 
+    // Metric sent to graphite will be prefixed with "$InternalMetricPrefix.$hostname.",
+    // default is "carbon.zipper"
+    "InternalMetricPrefix": "carbon.zipper",
+
     // Number of 100ms buckets to track request distribution in. Used to build
     // 'carbon.zipper.hostname.requests_in_0ms_to_100ms' metric and friends.
     // Requests beyond the last bucket are logged as slow


### PR DESCRIPTION
This commit added an ``InternalMetricPrefix`` conffile option to allow manual setting internal metric name prefix, so users can better control and organize the internal metrics.